### PR TITLE
Publish stepper position to joint state topic

### DIFF
--- a/stepper_eip_driver/launch/stepper.launch
+++ b/stepper_eip_driver/launch/stepper.launch
@@ -1,12 +1,14 @@
 <launch>
 <arg name="xaxis_host" default="192.168.0.11" />
 <arg name="joint_name" default="x_axis" />
+<arg name="joint_states_topic" default="/joint_states" />
 
 <group ns="xaxis">
     <param name="debug" type="bool" value="false" />
     <node pkg="stepper_eip_driver" type="stepper_node" name="stepper_node" output="log">
       <param name="host" value="$(arg xaxis_host)" />
       <param name="joint_name" value="$(arg joint_name)" />
+      <param name="joint_states_topic" value="$(arg joint_states_topic)" />
     </node>
 </group>
 

--- a/stepper_eip_driver/launch/stepper.launch
+++ b/stepper_eip_driver/launch/stepper.launch
@@ -1,10 +1,12 @@
 <launch>
 <arg name="xaxis_host" default="192.168.0.11" />
+<arg name="joint_name" default="x_axis" />
 
 <group ns="xaxis">
     <param name="debug" type="bool" value="false" />
     <node pkg="stepper_eip_driver" type="stepper_node" name="stepper_node" output="log">
       <param name="host" value="$(arg xaxis_host)" />
+      <param name="joint_name" value="$(arg joint_name)" />
     </node>
 </group>
 

--- a/stepper_eip_driver/src/stepper_node.cpp
+++ b/stepper_eip_driver/src/stepper_node.cpp
@@ -46,9 +46,9 @@ int main(int argc, char *argv[])
 
 
   // get sensor config from params
-  string host, local_ip, axis_name;
+  string host, local_ip, joint_name;
   ros::param::param<std::string>("~host", host, "192.168.0.1");
-  ros::param::param<std::string>("~axis_name", axis_name, "x_axis");
+  ros::param::param<std::string>("~joint_name", joint_name, "x_axis");
 
   ROS_INFO_STREAM("Host is: " << host);
   ros::param::param<std::string>("~local_ip", local_ip, "192.168.0.104");
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
       joint_state.header.stamp = ros::Time::now();
       joint_state.name.resize(1);
       joint_state.position.resize(1);
-      joint_state.name[0] = axis_name;
+      joint_state.name[0] = joint_name;
       joint_state.position[0] = stepper.ss.current_position / 1000.0;
       joint_state_pub.publish(joint_state);
 

--- a/stepper_eip_driver/src/stepper_node.cpp
+++ b/stepper_eip_driver/src/stepper_node.cpp
@@ -46,8 +46,9 @@ int main(int argc, char *argv[])
 
 
   // get sensor config from params
-  string host, local_ip;
+  string host, local_ip, axis_name;
   ros::param::param<std::string>("~host", host, "192.168.0.1");
+  ros::param::param<std::string>("~axis_name", axis_name, "x_axis");
 
   ROS_INFO_STREAM("Host is: " << host);
   ros::param::param<std::string>("~local_ip", local_ip, "192.168.0.104");
@@ -98,7 +99,7 @@ int main(int argc, char *argv[])
   ros::Publisher status_pub = nh.advertise<stepper_status>("stepper_status", 1);
 
   sensor_msgs::JointState joint_state;
-  ros::Publisher joint_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
+  ros::Publisher joint_state_pub = nh.advertise<sensor_msgs::JointState>("/joint_states", 1);
 
   ros::ServiceServer enable_service = nh.advertiseService("enable", &STEPPER::enable, &stepper);
   ros::ServiceServer move_service = nh.advertiseService("profileMove", &STEPPER::moveProfile, &stepper);
@@ -119,7 +120,7 @@ int main(int argc, char *argv[])
       joint_state.header.stamp = ros::Time::now();
       joint_state.name.resize(1);
       joint_state.position.resize(1);
-      joint_state.name[0] = "stepper_pos";
+      joint_state.name[0] = axis_name;
       joint_state.position[0] = stepper.ss.current_position / 1000.0;
       joint_state_pub.publish(joint_state);
 

--- a/stepper_eip_driver/src/stepper_node.cpp
+++ b/stepper_eip_driver/src/stepper_node.cpp
@@ -46,13 +46,20 @@ int main(int argc, char *argv[])
 
 
   // get sensor config from params
-  string host, local_ip, joint_name, joint_states_topic;
+  string host, local_ip;
   nh.param<std::string>("~host", host, "192.168.0.1");
-  nh.param<std::string>("~joint_name", joint_name, "x_axis");
-  nh.param<std::string>("~joint_states_topic", joint_states_topic, "/joint_states");
-
   ROS_INFO_STREAM("Host is: " << host);
   nh.param<std::string>("~local_ip", local_ip, "192.168.0.104");
+
+  // optionally publish ROS joint_state messages
+  bool publish_joint_state;
+  string joint_name, joint_states_topic;
+  nh.param<bool>("~publish_joint_state", publish_joint_state, false);
+  if (publish_joint_state)
+  {
+    nh.param<std::string>("~joint_name", joint_name, "x_axis");
+    nh.param<std::string>("~joint_states_topic", joint_states_topic, "/joint_states");
+  }
 
   boost::asio::io_service io_service;
   shared_ptr<TCPSocket> socket = shared_ptr<TCPSocket>(new TCPSocket(io_service));
@@ -99,8 +106,13 @@ int main(int argc, char *argv[])
   ros::Publisher stepper_pub = nh.advertise<stepper_inputs>("stepper_inputs", 1);
   ros::Publisher status_pub = nh.advertise<stepper_status>("stepper_status", 1);
 
+  // publisher and message for joint state
   sensor_msgs::JointState joint_state;
-  ros::Publisher joint_state_pub = nh.advertise<sensor_msgs::JointState>(joint_states_topic, 1);
+  ros::Publisher joint_state_pub;
+  if (publish_joint_state)
+  {
+    joint_state_pub = nh.advertise<sensor_msgs::JointState>(joint_states_topic, 1);
+  }
 
   ros::ServiceServer enable_service = nh.advertiseService("enable", &STEPPER::enable, &stepper);
   ros::ServiceServer move_service = nh.advertiseService("profileMove", &STEPPER::moveProfile, &stepper);
@@ -118,12 +130,15 @@ int main(int argc, char *argv[])
       // Collect status from controller, convert to ROS message format.
       stepper.updateDriveStatus(stepper.getDriveData());
 
-      joint_state.header.stamp = ros::Time::now();
-      joint_state.name.resize(1);
-      joint_state.position.resize(1);
-      joint_state.name[0] = joint_name;
-      joint_state.position[0] = stepper.ss.current_position / 1000.0;
-      joint_state_pub.publish(joint_state);
+      if (publish_joint_state)
+      {
+        joint_state.header.stamp = ros::Time::now();
+        joint_state.name.resize(1);
+        joint_state.position.resize(1);
+        joint_state.name[0] = joint_name;
+        joint_state.position[0] = stepper.ss.current_position / 1000.0;
+        joint_state_pub.publish(joint_state);
+      }
 
       //publish stepper inputs
       stepper_pub.publish(stepper.si);

--- a/stepper_eip_driver/src/stepper_node.cpp
+++ b/stepper_eip_driver/src/stepper_node.cpp
@@ -46,12 +46,13 @@ int main(int argc, char *argv[])
 
 
   // get sensor config from params
-  string host, local_ip, joint_name;
-  ros::param::param<std::string>("~host", host, "192.168.0.1");
-  ros::param::param<std::string>("~joint_name", joint_name, "x_axis");
+  string host, local_ip, joint_name, joint_states_topic;
+  nh.param<std::string>("~host", host, "192.168.0.1");
+  nh.param<std::string>("~joint_name", joint_name, "x_axis");
+  nh.param<std::string>("~joint_states_topic", joint_states_topic, "/joint_states");
 
   ROS_INFO_STREAM("Host is: " << host);
-  ros::param::param<std::string>("~local_ip", local_ip, "192.168.0.104");
+  nh.param<std::string>("~local_ip", local_ip, "192.168.0.104");
 
   boost::asio::io_service io_service;
   shared_ptr<TCPSocket> socket = shared_ptr<TCPSocket>(new TCPSocket(io_service));
@@ -99,7 +100,7 @@ int main(int argc, char *argv[])
   ros::Publisher status_pub = nh.advertise<stepper_status>("stepper_status", 1);
 
   sensor_msgs::JointState joint_state;
-  ros::Publisher joint_state_pub = nh.advertise<sensor_msgs::JointState>("/joint_states", 1);
+  ros::Publisher joint_state_pub = nh.advertise<sensor_msgs::JointState>(joint_states_topic, 1);
 
   ros::ServiceServer enable_service = nh.advertiseService("enable", &STEPPER::enable, &stepper);
   ros::ServiceServer move_service = nh.advertiseService("profileMove", &STEPPER::moveProfile, &stepper);


### PR DESCRIPTION
I added a joint state publisher to `stepper_node.cpp` as well as additional parameters to help identify each motor as unique. This allows simpler real-time visualization of links driven by the stepper motor in Rviz and other tools which expect robots to publish to `/joint_states`.